### PR TITLE
Fixed typos in log messages and comments

### DIFF
--- a/Building-a-release.txt
+++ b/Building-a-release.txt
@@ -11,4 +11,4 @@ Building a release
    - Creates zip file of target/awakening-<vers> folder
    - Copies zip file to ~/Dropbox/awakening
 5. Test that new package works
-6. Update the version number and  download link in the README.md file
+6. Update the version number and download link in the README.md file

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ The next time you run the program, it will ask if you want to resume a saved gam
 To enter a card play for the Jihadist side simply enter `j 121`.  This indicates that the
 Jihadist plays card #121.  For a US card play you would enter `u 200`.
 
-Use the `help` command to see all of the the available commands.  You can get further help for 
+Use the `help` command to see all the available commands.  You can get further help for 
 a specific command by typing its name after `help`. For example for help on the `show` 
-command type `help show`.
+command, type `help show`.
 
 The `show` command allows you to inspect the current state of the board.
 
-The `history` command allow you to review the current turn, previous turns or the 
+The `history` command allows you to review the current turn, previous turns or the 
 entire game log.
 
 The `rollback` command will let you restart the game from:
@@ -73,17 +73,17 @@ command is actually shorthand for `jihadist 121`.
 
 In fact this use of abbreviated prefixes works at every prompt in the game.  So if you are
 choosing the country where you want to conduct a Jihad, you can enter `sau` to indicate 
-`Saudi Arabia` or `uk` for `United Kingdom`.  If the prefix you type is not unqiue, the 
+`Saudi Arabia` or `uk` for `United Kingdom`.  If the prefix you type is not unique, the 
 program will display the valid choices.
 
 There is a `resolve plots` command, but you will rarely need to use it.  The program will
 detect when a new action phase has started and if there are unresolved plots, they will be
-resloved.
+resolved.
 
 When all cards for a turn have been played, use the `end turn` command to perform the
 end of turn housekeeping.
 
-When playing a campaign game and you come to the end of a particular deck of cards
+When playing a campaign game and you come to the end of a particular deck of cards,
 you must enter the appropriate command to let the software know that this has occurred:
 
     add awakening - The game starts using the Awakeing expansion rules.

--- a/src/main/scala/awakening/AwakeningCards.scala
+++ b/src/main/scala/awakening/AwakeningCards.scala
@@ -44,6 +44,8 @@ import scala.util.Random.shuffle
 import LabyrinthAwakening._
 import USBot.PlotInCountry
 
+import scala.annotation.tailrec
+
 object AwakeningCards {
   
   // Various tests used by the card events
@@ -181,7 +183,7 @@ object AwakeningCards {
     })
   }
   
-  // Countries with an awakening maker or adjacent to a country with an awakening marker.
+  // Countries with an awakening marker or adjacent to a country with an awakening marker.
   def faceBookCandidates: List[String] = countryNames(game.muslims filter { m =>
     m.canTakeAwakeningOrReactionMarker &&
     (m.awakening > 0 || (game.adjacentMuslims(m.name) exists (_.awakening > 0)))
@@ -422,7 +424,7 @@ object AwakeningCards {
         if (role == game.humanRole) {
           val choices = List(
             choice(reaperCandidates.nonEmpty, "remove",  "Remove up to 2 cells in one Muslim country"),
-            choice(true,                      "discard", "Randomly discard 1 card from the Jihadist hand")
+            choice(condition = true,                      "discard", "Randomly discard 1 card from the Jihadist hand")
           ).flatten
           askMenu("\nChoose one:", choices).head match {
             case "discard" =>
@@ -673,7 +675,7 @@ object AwakeningCards {
         else {
           // See Event Instructions table
           // If there are any WMD plots in the available box, the bot
-          // will remove one. Otherwise take a US players random card.
+          // will remove one. Otherwise take a US player's random card.
           if (game.availablePlots contains PlotWMD) {
             removeAvailableWMD(1)
           }
@@ -693,7 +695,7 @@ object AwakeningCards {
           case name::Nil =>
             val c = game.getCountry(name)
             // Must activate a sleeper if present, then remove any two others
-            // so only successfull if there are not sleeper to flip
+            // so only successful if there are not sleeper to flip
             c.sleeperCells == 0 && game.totalCellsOnMap <= 2 && c.totalCells == game.totalCellsOnMap
           case _ => false
         }
@@ -849,8 +851,8 @@ object AwakeningCards {
             choice(canAid,             "aid",       "Place 1 Aid marker"),
             choice(game.prestige < 12, "prestige",  "+1 Prestige"),
             choice(game.funding > 1,   "funding",   "-1 Funding"),
-            choice(true,               "posture",   "Select posture of 1 Schengen country"),
-            choice(true,               "draw",      "Select Reaper, Operation New Dawn, or Advisors from discard pile.")
+            choice(condition = true,   "posture",   "Select posture of 1 Schengen country"),
+            choice(condition = true,   "draw",      "Select Reaper, Operation New Dawn, or Advisors from discard pile.")
           ).flatten 
 
           askMenu(s"Do any $numActions of the following:", choices, numActions, repeatsOK = false) foreach { action =>
@@ -965,7 +967,7 @@ object AwakeningCards {
       (role: Role) => {
         // Get candidates in this priority order:
         // 1. Muslims with besieged regime markers that can take an awakening marker
-        // 2. Muslims with besiged regime markers (cannot take awakening because of Civil War)
+        // 2. Muslims with besieged regime markers (cannot take awakening because of Civil War)
         // 3. Muslims that can take an awakening marker.
         val possibles = List(
           game.muslims filter (m => m.besiegedRegime && m.canTakeAwakeningOrReactionMarker),
@@ -1139,7 +1141,7 @@ object AwakeningCards {
           val candidates = countryNames(game.muslims filter (m => m.civilWar && m.totalCells > m.totalTroopsAndMilitia))
           val target = shuffle(USBot.highestCellsMinusTandM(candidates)).head
           addEventTarget(target)
-          performRegimeChange("track", target, 6)  // Bot always uses exatly 6 troops for regime change
+          performRegimeChange("track", target, 6)  // Bot always uses exactly 6 troops for regime change
         }
       }
     )),
@@ -1206,7 +1208,7 @@ object AwakeningCards {
       (role: Role) => {
         val maxMilitia = 4 min game.militiaAvailable
         if (role == game.humanRole) {
-          // Card allow placing militia or respositioning militia in the Gulf Union countries.
+          // Card allow placing militia or repositioning militia in the Gulf Union countries.
           val existingMilitia = (GulfUnionCountries exists (name => game.getMuslim(name).militia > 0))
           val actions = List(
             if (game.militiaAvailable > 0) Some("place")      else None,
@@ -1214,7 +1216,7 @@ object AwakeningCards {
           ).flatten
           val choices = List(
             "place"      -> "Place up to 4 militia in one Gulf Union (or adjacent) country",
-            "reposition" -> "Repositon militia in Gulf Union countries")
+            "reposition" -> "Reposition militia in Gulf Union countries")
           val placeCandidates = gulfUnionCandidates.toList.sorted
           val action = if (actions.size == 1) actions.head 
           else
@@ -1630,7 +1632,7 @@ object AwakeningCards {
         else
           addSleeperCellsToCountry(target, num min game.cellsAvailable)
         rollCountryPosture(Serbia)
-        log("Travel to/within Schengen countries requires a roll for the rest this turn")
+        log("Travel to/within Schengen countries requires a roll for the rest of this turn")
       }
     )),
     // ------------------------------------------------------------------------
@@ -1686,7 +1688,7 @@ object AwakeningCards {
             choice(canPlot1,   "plot1",    "Place a level 1 plot"),
             choice(canPlot2,   "plot2",    "Place a level 2 plot"),
             choice(canBesiege, "besiege",  "Place a besieged regime marker"),
-            choice(true,       "draw",     "Select Pirates, Boko Haram, or Islamic Maghreb from discard pile")
+            choice(condition = true, "draw",     "Select Pirates, Boko Haram, or Islamic Maghreb from discard pile")
           ).flatten 
           askMenu("\nDo any 2 of the following:", choices, 2, repeatsOK = false) foreach { action =>
             println()
@@ -1767,7 +1769,7 @@ object AwakeningCards {
                 addAvailablePlotToCountry(plotTarget.get, plot)
               case _ =>
                 log("Select Pirates, Boko Haram, or Islamic Maghreb from discard pile")
-                log("and place it on top of the the Jihadist's hand of cards")
+                log("and place it on top of the Jihadist's hand of cards")
             }
           }
         }
@@ -1959,9 +1961,9 @@ object AwakeningCards {
           log("Failure")
           val c = game.getCountry(Iran)
           if (c.activeCells > 0)
-            removeCellsFromCountry(Iran, 1, 0, false, addCadre = true)
+            removeCellsFromCountry(Iran, 1, 0, sadr = false, addCadre = true)
           else
-            removeCellsFromCountry(Iran, 0, 1, false, addCadre = true)
+            removeCellsFromCountry(Iran, 0, 1, sadr = false, addCadre = true)
         }
       }
     )),
@@ -2467,7 +2469,7 @@ object AwakeningCards {
         addEventTarget(target)
         removeCellsFromCountry(target, actives, sleepers, sadr, addCadre = false)
         plots foreach { p => addAvailablePlotToCountry(target, p) }
-        performJihads(JihadTarget(target, 2, 0, false, major = false)::Nil, ignoreFailures = true)
+        performJihads(JihadTarget(target, 2, 0, sadr = false, major = false)::Nil, ignoreFailures = true)
       }
     )),
     // ------------------------------------------------------------------------
@@ -2518,7 +2520,7 @@ object AwakeningCards {
           log(s"The $Jihadist Bot draws the candidate card nearest the top of the removed cards pile...")
 
         val prompt = s"Enter # of the card retrieved from out of play: "
-        val cardNum = askCardNumber(prompt, None, false, false, true).get
+        val cardNum = askCardNumber(prompt, None, allowNone = false, only3Ops = false, removedLapsingOK = true).get
         game = game.copy(cardsRemoved = game.cardsRemoved filterNot (_ == cardNum))
         decreasePrestige(1)
       }
@@ -2610,7 +2612,7 @@ object AwakeningCards {
             val action = if (choices.isEmpty) None else askMenu("\nChoose one:", choices).headOption
             val from = if (action == Some("cells")) {
               val sources = countryNames(game.countries filter (c => c.name != target && c.cells > 0))
-              askCellsFromAnywhere(2, true, sources, sleeperFocus = false)
+              askCellsFromAnywhere(2, trackOK = true, sources, sleeperFocus = false)
             }
             else
               Nil
@@ -2732,8 +2734,8 @@ object AwakeningCards {
         if (role == game.humanRole) {
           val choices = List(
             choice(opRes > 0, "reserves", s"Steal opponent's ${amountOf(opRes,"reserve Op")}"),
-            choice(true,      "posture",  "Set the posture of China, Russia, or India"),
-            choice(true,      "place",    "Place a cadre"),
+            choice(condition = true,      "posture",  "Set the posture of China, Russia, or India"),
+            choice(condition = true,      "place",    "Place a cadre"),
             choice(cadres,    "remove",   "Remove a cadre")
           ).flatten
 
@@ -2859,13 +2861,13 @@ object AwakeningCards {
             List(
               choice(m.canTakeAidMarker,      "+aid", "Place aid marker"),
               choice(m.aidMarkers > 0,        "-aid", "Remove aid marker"),
-              choice(canBesiege,              "+bsg", "Place besiged regime marker"),
+              choice(canBesiege,              "+bsg", "Place besieged regime marker"),
               choice(m.besiegedRegime,        "-bsh", "Remove besieged regime marker"),
               choice(canAwake,                "+awa", "Place awakening marker"),
               choice(m.awakening > 0,         "-awa", "Remove awakening marker"),
               choice(canAwake,                "+rea", "Place reaction marker"),
               choice(m.reaction > 0,          "-rea", "Remove reaction marker"),
-              choice(canMilitia,              "+mil", "Place 2 milita"),
+              choice(canMilitia,              "+mil", "Place 2 militia"),
               choice(m.militia > 0,           "-mil", "Remove 2 militia"),
               choice(game.cellsAvailable > 0, "+cel", "Place 2 cells"),
               choice(m.totalCells > 0,        "-cel", "Remove 2 cells")
@@ -2881,7 +2883,7 @@ object AwakeningCards {
             ).flatten
           }
           if (choices.isEmpty)
-            log(s"There are no valid action that can be taken in $name")
+            log(s"There are no valid actions that can be taken in $name")
           else {
             addEventTarget(name)
             testCountry(name)
@@ -3023,7 +3025,7 @@ object AwakeningCards {
             addEventTarget(name)
             testCountry(name)
             val choices = List(
-              choice(n.totalCells > 0, "cell" , "Remve a cell"),
+              choice(n.totalCells > 0, "cell" , "Remove a cell"),
               choice(n.hasCadre,       "cadre", "Remove cadre"),
               choice(n.hasPlots,       "plot" , "Alert a plot")
             ).flatten
@@ -3079,7 +3081,7 @@ object AwakeningCards {
           increasePrestige(1)
         }
         else
-          log("The event has no effect because the troop comittment is War")
+          log("The event has no effect because the troop commitment is War")
       }
     )),
     // ------------------------------------------------------------------------
@@ -3244,7 +3246,7 @@ object AwakeningCards {
             val withCells = countryNames(game.countries filter (c => c.name != target && c.cells > 0))
             println()
             println(s"Choose ${amountOf(num, "cell")} to place in $target")
-            val sources = askCellsFromAnywhere(num, true, withCells, sleeperFocus = false)
+            val sources = askCellsFromAnywhere(num, trackOK = true, withCells, sleeperFocus = false)
             println()
             moveCellsToTarget(target, sources)
             // Count how many were actually placed (based on availability)
@@ -3887,7 +3889,7 @@ object AwakeningCards {
       (role: Role) => if (role == US) {
         val iran = game getCountry Iran
         if (iran.wmdCache > 0) {
-          log("Remove the Iraninan WMD from the game")
+          log("Remove the Iranian WMD from the game")
           increasePrestige(iran.wmdCache)
           iran match {
             case m: MuslimCountry    => game = game.updateCountry(m.copy(wmdCache = 0))
@@ -3973,7 +3975,7 @@ object AwakeningCards {
         addEventTarget(Syria)
         startCivilWar(Syria)
         val (cells, militia) = if (role == game.humanRole) {
-          val choices = List("cells"   -> "Place 2 cells and 1 milita in Syria",
+          val choices = List("cells"   -> "Place 2 cells and 1 militia in Syria",
                              "militia" -> "Place 2 militia and 1 cell in Syria")
           if (askMenu("\nChoose one:", choices).head == "cells") (2, 1) else (1, 2)
         }
@@ -4020,7 +4022,7 @@ object AwakeningCards {
         // See Event Instructions table
         removeGlobalEventMarker(Fracking) // Cancels effects of "Fracking" marker
         if (role == game.humanRole)
-          log(s"$role player draws a card other than Oil Price Spike from the discad pile")
+          log(s"$role player draws a card other than Oil Price Spike from the discard pile")
         else if (role == US)
           log(s"$US Bot draws highest Ops US associated card (at random) from the discard pile ")
         else

--- a/src/main/scala/awakening/BotHelpers.scala
+++ b/src/main/scala/awakening/BotHelpers.scala
@@ -93,7 +93,7 @@ trait BotHelpers {
   //
   // Each filter is first used against the input and if the filter does not find any matching
   // candidates, the next filter is given a chance.
-  // As soon as a filter finds at least one matching country, then the procees stops and the
+  // As soon as a filter finds at least one matching country, then the process stops and the
   // results from that filter are returned.
   // If none of the filters finds at least one matching country we return Nil, 
   // which indicates that no valid candidates were found for the OpP flowchart.
@@ -119,11 +119,11 @@ trait BotHelpers {
   }
   
   
-  // Process the list of countries by each CountryFilter in the prorities list.
-  // The prorities list reprsents a single column in a Priorities Table.
+  // Process the list of countries by each CountryFilter in the priorities list.
+  // The priorities list represents a single column in a Priorities Table.
   // In this function each filter is processed in order until we have used all filters
   // in the list to narrow the choices to a single country.  If we go through all of
-  // the filters and we stil have more than one viable country, then we pick one at
+  // the filters and we still have more than one viable country, then we pick one at
   // random.
   // Note: The only time this function will return None, is if the original list of
   //       countries is empty.
@@ -142,7 +142,7 @@ trait BotHelpers {
         case (cs, f::fs) =>
           (f filter cs) match {
             case Nil =>
-              botLog(s"topPriority ($f) falied")
+              botLog(s"topPriority ($f) failed")
               nextPriority(cs, fs) // Filter entire list by next priority
             case rs  =>
               botLog(s"topPriority ($f) [${(rs map (_.name) mkString ", ")}]")

--- a/src/main/scala/awakening/FUtil.scala
+++ b/src/main/scala/awakening/FUtil.scala
@@ -121,7 +121,7 @@ object FUtil {
       path.substring(0, pos) + ext
   }
 
-  /** Return the extension portion of the path's basname starting form the rightmost period.
+  /** Return the extension portion of the path's basename starting from the rightmost period.
   *
   *   If the base name does not contain a period, or if it ends with a period then
   *   an empty string is returned.
@@ -625,7 +625,7 @@ object FUtil {
     return s == NUL
   }
 
-  /** Returns the filenames found by expanding pattern which is an String or a Seq[String],
+  /** Returns the filenames found by expanding pattern which is a String or a Seq[String],
   *
   *   Note that this pattern is not a regexp (it‘s closer to a shell glob).
   *   Note that case sensitivity depends on your system.
@@ -694,7 +694,7 @@ object FUtil {
       //      For each match attempt to match with the next glob, and so on...
 
       // This filter is used by the glob_recursive method to get only the subdirectories in a
-      // given directory. Hidden directores (that start with a period : .svn, .git) are not
+      // given directory. Hidden directories (that start with a period : .svn, .git) are not
       // returned unless the FNM_DOTMATCH flag has been specified.
       object SubdirsOnly extends FilenameFilter {
         def accept(dir: File, name: String) = {
@@ -742,7 +742,7 @@ object FUtil {
         def list(dir: File, only_subdirs: Boolean): Seq[String] = Seq(name)
       }
 
-      // Return true if the pattern has special glob charcters
+      // Return true if the pattern has special glob characters
       def has_magic(pat: String): Boolean = {
         var escaped = false
         for (c <- pat) c match {
@@ -816,7 +816,7 @@ object FUtil {
 
       // Filter out empty sub patterns. This would result when two or more adjacent directory separators
       // were encountered ("foo//bar" == "foo/bar")
-      // Also remove redunant recursive patterns ("**/**/" == "**/")
+      // Also remove redundant recursive patterns ("**/**/" == "**/")
       val globs = fix_recursives(split_by_dirs(fixed_pattern, Seq()).reverse.filter(_ != "")).map { pat =>
         pat match {
           case ".." | "."          => Special(pat)
@@ -923,7 +923,7 @@ object FUtil {
     */
     def cleanPath: Pathname = {
       val EMPTY = List[String]()
-      // Consequtive slashes are removed by the #filenames method.
+      // Consecutive slashes are removed by the #filenames method.
       // `segs` is the cleaned path segments,
       // `count` is the number of leading `..` that must be accounted for.
       val (count, segs) = (filenames foldRight (0, EMPTY)) { case (seg, (count, segs)) =>
@@ -1006,7 +1006,7 @@ object FUtil {
       else
         throw new IllegalStateException(s"${toString()} is not a directory!")
 
-    /** Return the extension portion of the path's basname starting form the rightmost period.
+    /** Return the extension portion of the path's basename starting from the rightmost period.
     *
     *   If the base name does not contain a period, or if it ends with a period then
     *   an empty string is returned.
@@ -1029,9 +1029,9 @@ object FUtil {
     *   The test function will be called with each candidate Pathname. It must return
     *   one of:
     *      Pathname.INCLUDE -> The pathname will be included in the list
-    *      Pathname.EXCLUDE -> The pathname will be excluded from the list but it's children if any
+    *      Pathname.EXCLUDE -> The pathname will be excluded from the list but its children if any
     *                          will still be considered.
-    *      Pathname.PRUNE   -> The pathname will be exclued from the list and none of it's children
+    *      Pathname.PRUNE   -> The pathname will be excluded from the list and none of its children
     *                          will be considered.
     */
     import Pathname.{FindVerb, INCLUDE, EXCLUDE, PRUNE}
@@ -1155,7 +1155,7 @@ object FUtil {
       finally { try w.close() catch { case _: Throwable =>} }
     }
 
-    /** Returns the parent of the file/dir repesented by this Pathname */
+    /** Returns the parent of the file/dir represented by this Pathname */
     def parent: Pathname = if (path == ".") Pathname("..") else dirname
 
     /**  Read the contents of the file and return as an array of bytes.
@@ -1180,7 +1180,7 @@ object FUtil {
     /**  Returns a new Pathname represents the same path as the pathname except that
     *    it is relative to the given path name.
     *
-    *    If `this.isAbsolute` must equal `other.isAbsolute'.  In other words both paths
+    *    If `this.isAbsolute` must equal `other.isAbsolute`.  In other words both paths
     *    must be absolute OR both paths must be relative.
     *
     *    This method does not access the file system.
@@ -1249,8 +1249,8 @@ object FUtil {
     *
     *   IMPORTANT: BE VERY CAREFUL using this method !!!!
     *
-    *   return true if all directories/files were delete sucessfully.
-    *   If any deletes fail, the rest are still tried, but the the method will
+    *   return true if all directories/files were delete successfully.
+    *   If any deletes fail, the rest are still tried, but the method will
     *   return false to indicate that there was at least one failure.
     */
     def rmtree(): Boolean = {

--- a/src/main/scala/awakening/ForeverWarCards.scala
+++ b/src/main/scala/awakening/ForeverWarCards.scala
@@ -1079,7 +1079,7 @@ object ForeverWarCards {
       (_: Role, _: Boolean) => airAmericaCaliphateCandidates.nonEmpty || airAmericaNonCaliphateCandidates.nonEmpty
       ,
       (role: Role) => {
-        //  Allows US player to remove up to 4 cells from any calipate members
+        //  Allows US player to remove up to 4 cells from any caliphate members
         //  or up to 3 cells from any Civil War/Regime Change countries
         if (role == game.humanRole) {
           val choices = List(
@@ -1174,7 +1174,7 @@ object ForeverWarCards {
       (_: Role, _: Boolean) => true
       ,
       (role: Role) => {
-        log("During Attrition at the end of this turn, Add +1 to the")
+        log("During Attrition at the end of this turn, add +1 to the")
         log("number of cells to be removed for each hit secured by the US player.")
         decreasePrestige(1)
       }
@@ -1472,7 +1472,7 @@ object ForeverWarCards {
         else {
           // Bot
           // We will select the cells one at a time, because
-          // removal of a cell could change the Bots priorities
+          // removal of a cell could change the Bot's priorities
           @tailrec def nextRemoval(numLeft: Int): Unit = {
             val withCells = candidates filter (name => game.getMuslim(name).totalCells > 0)
             if (numLeft > 0 && withCells.nonEmpty) {
@@ -2174,7 +2174,7 @@ object ForeverWarCards {
         testCountry(Caucasus)
         val result = game.prestigeModifier - game.gwotPenalty
         val opPoints = -result
-        log(s"GWOT penalty (-${game.gwotPenalty}) + prestige modifer (${game.prestigeModifier}) = $result")
+        log(s"GWOT penalty (-${game.gwotPenalty}) + prestige modifier (${game.prestigeModifier}) = $result")
         if (result >= 0)
           log("There is no effect")
         else {
@@ -2637,7 +2637,7 @@ object ForeverWarCards {
         addEventMarkersToCountry(Iran, TehranBeirutLandCorridor)
         log()
         log("Iran is now a 3 Resource country and will remain so as long as")
-        log("neither Iran, Syria or Lebanon become Ally or Civil War")
+        log("neither Iran, Syria nor Lebanon become Ally or Civil War")
         log("and at least one of Iraq and Turkey are not Ally or Civil War")
       }
     )),
@@ -3889,7 +3889,7 @@ object ForeverWarCards {
         
         if (shiaCandidates.nonEmpty) {
           val (target, (actives, sleepers, sadr)) = if (role == game.humanRole) {
-            val t = askCountry("Remove cell from which Shix-Mix country: ", shiaCandidates)
+            val t = askCountry("Remove cell from which Shia-Mix country: ", shiaCandidates)
             (t, askCells(t, 1, true))
           }
           else {
@@ -3921,7 +3921,7 @@ object ForeverWarCards {
         
         if (shiaCandidates.nonEmpty && game.cellsAvailable > 0) {
           val target = if (role == game.humanRole)
-            askCountry("Place a cell in which Shix-Mix country: ", shiaCandidates)
+            askCountry("Place a cell in which Shia-Mix country: ", shiaCandidates)
           else
             JihadistBot.recruitTravelToPriority(shiaCandidates).get
             

--- a/src/main/scala/awakening/JihadistBot.scala
+++ b/src/main/scala/awakening/JihadistBot.scala
@@ -86,12 +86,12 @@ object JihadistBot extends BotHelpers {
   // Sadr cannot travel
   def unusedCellsOnMapForTravel = (game.countries map unusedCells).sum
   
-  // Poor country with 1 to 4 more cells than Troops and Milita and Jihad success possible
+  // Poor country with 1 to 4 more cells than Troops and Militia and Jihad success possible
   // I added a couple of sanity checks that are not in the Bot Flowchart:
   // - Do not consider Pakistan if Benazir Bhutto is in play
   // - Do not consider countries where the US player has stacked
   //   so many troops/militia that there are not enough cells in
-  //   the game to make a major jihid possible
+  //   the game to make a major jihad possible
   def poorMuslimNeedsCellsForMajorJihad(m: MuslimCountry): Boolean = 
     m.isPoor &&
     !(m.name == Pakistan && m.hasMarker(BenazirBhutto)) &&
@@ -152,7 +152,7 @@ object JihadistBot extends BotHelpers {
                   c => c.name == Pakistan && c.wmdCache > 0)
                   
   // 6. Philippines if would prestige - 1
-  val PhilippinesPriority = new CriteriaFilter("Phillipines", 
+  val PhilippinesPriority = new CriteriaFilter("Philippines",
                   muslimTest(m => m.name == Philippines &&
                                   m.totalTroops > 0 &&
                                   game.prestige > 1))
@@ -204,7 +204,7 @@ object JihadistBot extends BotHelpers {
   // 22. Russia
   val RussiaPriority = new CriteriaFilter("Russia", _.name == Russia)
   
-  // 23. No Disrupt pretige gain
+  // 23. No Disrupt prestige gain
   val NoDisruptPretigePriority = new CriteriaFilter("No Disrupt prestige gain",
                   muslimTest(_.totalTroopsThatAffectPrestige == 0, nonMuslim = true))
                   
@@ -230,13 +230,13 @@ object JihadistBot extends BotHelpers {
   val DisruptPrestigePriority = new CriteriaFilter("Disrupt prestige gain", 
                   muslimTest(m => m.disruptAffectsPrestige && game.prestige < 12))
                   
-  // 31. Cival War
+  // 31. Civil War
   val CivilWarPriority = new CriteriaFilter("Civil War", muslimTest(_.civilWar))
   
   // 32. Neutral
   val NeutralPriority = new CriteriaFilter("Neutral", muslimTest(_.isNeutral))
   
-  // 33. Besieged Regmime (Already defined at #7)
+  // 33. Besieged Regime (Already defined at #7)
   
   // 34. Adjacent Good Ally
   val AdjacentGoodAllyPriority = new CriteriaFilter("Adjacent Good Ally", 
@@ -277,7 +277,7 @@ object JihadistBot extends BotHelpers {
   
   val PoorTroopsActiveCellsFilter = new CriteriaFilter("Poor with troops and active cells",
                   muslimTest(m => m.isPoor && activeCells(m) > 0))
-  val PoorNeedCellsforMajorJihad = new CriteriaFilter("Poor, 1-4 more cells that troops/militia and JSP",
+  val PoorNeedCellsforMajorJihad = new CriteriaFilter("Poor, 1-4 more cells than troops/militia and JSP",
                   muslimTest(m => poorMuslimNeedsCellsForMajorJihad(m)))
   // Best DRM but Islamist Rule last.
   // I'm assuming that if there are any Civil War or Regime change countries (even with negative DRMs)
@@ -486,7 +486,7 @@ object JihadistBot extends BotHelpers {
   }
   
   
-  // This is used for some events where we want to check the priorites only,
+  // This is used for some events where we want to check the priorities only,
   // and skip the flowchart.
   def travelFromPriorities(toCountry: String, names: List[String]): Option[String] = {
     val priorities = List(
@@ -497,7 +497,7 @@ object JihadistBot extends BotHelpers {
     topPriority(game getCountries names, priorities) map (_.name)
   }
   
-  // Jihadisht Operations Flowchart definitions.
+  // Jihadist Operations Flowchart definitions.
   sealed trait Operation extends OpFlowchartNode
   case object RecruitOp    extends Operation
   case object TravelOp     extends Operation
@@ -553,7 +553,7 @@ object JihadistBot extends BotHelpers {
   }
   
   // This object incorporates two boxes on the Flowchart
-  // Finds a poor countries in need of cells for major jihad,
+  // Finds poor countries in need of cells for major jihad,
   // Finds the highest priority travel destination among them and checks
   // to see if there is a cell in an adjacent country.
   object PoorNeedCellsforMajorJihadDecision extends OperationDecision {
@@ -754,9 +754,9 @@ object JihadistBot extends BotHelpers {
       throw new IllegalStateException(s"JihadistBot.chooseTroopOrMilitiaToRemove($name) not units present")
   }
   
-  // The Bot will declare the Calipahate if it results in  an auto win, 
+  // The Bot will declare the Caliphate if it results in an auto win,
   // or if there is at least one other adjacent country that qualifies to be part
-  // of the Calipahte.
+  // of the Caliphate.
   def willDeclareCaliphate(capital: String): Boolean = {
     canDeclareCaliphate(capital) &&
     (game.islamistResources == 5 || game.caliphateDaisyChain(capital).size > 1)
@@ -825,7 +825,7 @@ object JihadistBot extends BotHelpers {
   
   // Attempt to recruit as many times as possible up to 3
   // If we run out of card ops and there are still cells available, use reserves
-  // If we run out of cells and still have card ops (not reserves), the use the
+  // If we run out of cells and still have card ops (not reserves), then use the
   // excess card ops for radicalization.
   // Returns the number of Ops used.
   def recruitOperation(card: Card): Int = {
@@ -842,7 +842,7 @@ object JihadistBot extends BotHelpers {
   }
   
   def performRecruit(ops: Int, ignoreFunding: Boolean = false, madrassas: Boolean = false): Unit = {
-    // We should always find a target for recuit operations.
+    // We should always find a target for recruit operations.
     val target = recruitTarget(game.recruitTargets(madrassas = madrassas)) getOrElse {
       throw new IllegalStateException("recruitOperation() should always find a target")
     }
@@ -894,7 +894,7 @@ object JihadistBot extends BotHelpers {
   // For each source country, make as many attempts as possible, before
   // moving on to the next source (as long as Ops are remaining)
   // - Only travel the last cell out of an Auto Recruit country if
-  //   there two or more other Auto Recruit countries with cells.
+  //   there are two or more other Auto Recruit countries with cells.
   // - Select active cells for travel before sleeper cells
   // - Never travel sleeper cells within the same country
   // Returns the number of Ops used.
@@ -917,7 +917,7 @@ object JihadistBot extends BotHelpers {
       countryNames(game.countries)
     
     val toName = travelToTarget(toCandidates) getOrElse {
-      throw new IllegalStateException("travelOperation() should always find \"travel to\" ttarget")
+      throw new IllegalStateException("travelOperation() should always find \"travel to\" target")
     }
     
     // Count sadr here, but below when finding cells to move.
@@ -1188,7 +1188,7 @@ object JihadistBot extends BotHelpers {
   // The opsUsed parameter is the number of Ops used to perform the card operation.
   // If this value is less than the number of Ops on the card, then we will 
   // perform radicalization until a maximum of 3 Ops total have been used using
-  // and availble reserves as necessary.
+  // any available reserves as necessary.
   // If the opUsed is greater than or equal to the number of Ops on the card,
   // then we do nothing.
   def radicalization(card: Card, opsUsed: Int): Unit = {
@@ -1253,7 +1253,7 @@ object JihadistBot extends BotHelpers {
   
   // Travel to Untested non-Muslim countries while the US is Hard to
   // try and increase the GWOT penalty.
-  // We give preference to cells in adacent countries to avoid die rolls
+  // We give preference to cells in adjacent countries to avoid die rolls
   // when necessary.
   // cardsOps   - The number of unused Ops remaining from the card
   // reserveOps - The number of unused Ops remaining from reserves
@@ -1485,7 +1485,7 @@ object JihadistBot extends BotHelpers {
         }
         else {
          travelFromTarget(UnitedStates, sources) match {
-           case None => completed   // No more source countrie
+           case None => completed   // No more source countries
            case Some(from) => 
              performTravels(createTravelAttempt(from)::Nil) match {
                case (_, true)::Nil => usedCells(UnitedStates).addSleepers(1)

--- a/src/main/scala/awakening/Json.scala
+++ b/src/main/scala/awakening/Json.scala
@@ -210,7 +210,7 @@ object Json {
   }
 
 
-  // Parses a JSON String representation into its native Scala reprsentation.
+  // Parses a JSON String representation into its native Scala representation.
   def parse(s: String): Any = (new JsonParser).parse(s)
 }
 

--- a/src/main/scala/awakening/LabyrinthAwakening.scala
+++ b/src/main/scala/awakening/LabyrinthAwakening.scala
@@ -56,7 +56,7 @@ object LabyrinthAwakening {
     else
       (askOneOf(prompt, 1 to 6, allowAbort = allowAbort) map (_.toInt)).get
   
-  // If the given role is human the prompt if necessary otherwise produce the roll automatically
+  // If the given role is human, then prompt if necessary, otherwise produce the roll automatically
   def getDieRoll(role: Role, prompt: String = "Enter die roll: ", allowAbort: Boolean = true): Int = {
     if (role == game.humanRole)
       humanDieRoll(prompt, allowAbort)
@@ -764,7 +764,7 @@ object LabyrinthAwakening {
   }
   
   sealed trait Play {
-    def name: String  // Used for qantifying type in save game files
+    def name: String  // Used for quantifying type in save game files
     def numCards: Int
   }
   sealed trait CardPlay extends Play {
@@ -780,7 +780,7 @@ object LabyrinthAwakening {
   }
   case class PlayedReassement(card1: Int, card2: Int) extends CardPlay {
     val role = US
-    override def name = "PlayedReassement"
+    override def name = "PlayedReassessment"
     override def numCards = 2
     override def toString() = s"$role played ${cardNumAndName(card1)} and ${cardNumAndName(card2)}"
   }
@@ -1228,7 +1228,7 @@ object LabyrinthAwakening {
       case _           =>  2
     }
     
-    // Returns the current gwot 
+    // Returns the current GWOT
     // posture (Soft, Even, Hard)
     // value 0, 1, 2, 3
     def gwot: (String, Int) = {
@@ -1276,7 +1276,7 @@ object LabyrinthAwakening {
     def troopsAvailable  = 15 - offMapTroops - troopsOnMap
     def militiaAvailable = 15 - militiaOnMap
     
-    // Extra cells are only useable when funding is as 9 or by event or civil war attrition.
+    // Extra cells are only usable when funding is at 9 or by event or civil war attrition.
     // If some of those cells are on the map and the training camp/al-Baghdadai is removed, those
     // extra cells remain on the map until eliminated.
     // We use the extraCells field to keep track of the training camp status:
@@ -1575,7 +1575,7 @@ object LabyrinthAwakening {
       b.toList
     }
     
-    // If show all is false, then some attriubtes will not be displayed
+    // If show all is false, then some attributes will not be displayed
     // if they have value of zero.
     def countrySummary(name: String, showAll: Boolean = false): Seq[String] = {
       val b = new ListBuffer[String]
@@ -2083,7 +2083,7 @@ object LabyrinthAwakening {
         val name = cardNumAndName(num)
         removedLapsingOK match {
           case false if game.cardRemoved(num) =>
-            println(s"$name has been removed from from the game")
+            println(s"$name has been removed from the game")
             true
           case false if game.cardLapsing(num) =>
             println(s"$name is currently lapsing")
@@ -2131,7 +2131,7 @@ object LabyrinthAwakening {
       }
     }
   }
-  // Convenience method for createing choices for the askMenu() function.
+  // Convenience method for creating choices for the askMenu() function.
   def choice(condition: Boolean, value: String, desc: String): Option[(String, String)] =
     if (condition) Some(value -> desc) else None
   
@@ -2177,7 +2177,7 @@ object LabyrinthAwakening {
   // This method is used when a number of items such as troops, sleeper cells, etc.
   // must be selected from the map.
   // targets     - a list MapItem instances where items can be selected.
-  // numItems    - the number that must be selectd
+  // numItems    - the number that must be selected
   // name        - should be the singular name of the item being selected (troop, sleeper cell)
   // Returns the list if MapItems with the results.
   // Before calling this, the caller should print a line to the terminal describing
@@ -2454,7 +2454,7 @@ object LabyrinthAwakening {
     for ((drm, desc) <- allDrms)
       log(f"$drm%+d  $desc")
     if (allDrms.nonEmpty)
-      log(s"Modifed roll: $modifiedDie")
+      log(s"Modified roll: $modifiedDie")
     
     setUSPosture(newPosture)
   }
@@ -2477,7 +2477,7 @@ object LabyrinthAwakening {
     log(s"Die roll: $die")
     if (drm != 0) {
       log(f"$drm%+d")
-      log(s"Modifed roll: $modifiedDie")
+      log(s"Modified roll: $modifiedDie")
     }
     val newPosture = if (modifiedDie < 5) Soft else Hard
     if (n.posture == newPosture)
@@ -2554,7 +2554,7 @@ object LabyrinthAwakening {
     modRoll
   }
 
-  // Return true if no caliphate exists and the the given country is a caliphate candidate.
+  // Return true if no caliphate exists and the given country is a caliphate candidate.
   def canDeclareCaliphate(capital: String): Boolean  =
     game.useExpansionRules       &&
     !game.caliphateDeclared      && 
@@ -2562,7 +2562,7 @@ object LabyrinthAwakening {
     (game getMuslim capital).caliphateCandidate
 
   def askDeclareCaliphate(capital: String): Boolean =
-    askYorN(s"Do you wish to declare a Caliphate with $capital as the the Captial (y/n)? ")
+    askYorN(s"Do you wish to declare a Caliphate with $capital as the Capital (y/n)? ")
 
 
   // Throws an exception if a Caliphate already exists
@@ -2597,9 +2597,9 @@ object LabyrinthAwakening {
   
   
   // Important: Assumes that the game has already been updated, such that the
-  // previousCapital is no longer a caliphateCandidate! Othewise the caliphate
-  // size comparisons for the the new capital candidate would include the old
-  // capital which is wrong.
+  // previousCapital is no longer a caliphateCandidate! Otherwise the caliphate
+  // size comparisons for the new capital candidate would include the old
+  // capital, which is wrong.
   def displaceCaliphateCapital(previousCapital: String): Unit = {
     // Used when the Bot is selecting new caliphate capital
     case class CaliphateCapitalCandidate(m: MuslimCountry) {
@@ -2634,7 +2634,7 @@ object LabyrinthAwakening {
     else {
       // If Jihadist is human, ask them to pick the new capital.
       // If Jihadist is a bot, the country that connects to the 
-      // largest number of daisy chained caliphate memeber.
+      // largest number of daisy chained caliphate members.
       // Then pick one at random among any ties.
       val newCapitalName = if (adjacents.size == 1)
         adjacents.head.name
@@ -2643,9 +2643,9 @@ object LabyrinthAwakening {
         askCountry(s"Choose new Caliphate capital (${orList(choices)}): ", choices, allowAbort = false)
       }
       else {
-        // The Bot pick the best candidate for the new capital base on
-        // the set of conditons outlined by compareCapitalCandidates().
-        // We sort the best to worst.  If more than one has the best score then 
+        // The Bot pick the best candidate for the new capital based on
+        // the set of conditions outlined by compareCapitalCandidates().
+        // We sort the best to worst.  If more than one has the best score, then
         // we choose randomly among them.
         val sorted = adjacents.map(CaliphateCapitalCandidate).sorted
         val best   = sorted.takeWhile(compareCapitalCandidates(_, sorted.head) == 0) map (_.m.name)
@@ -2672,7 +2672,7 @@ object LabyrinthAwakening {
     }
   }
 
-  // Select a random county to take an awkakening or reaction marker
+  // Select a random county to take an awakening or reaction marker
   def randomConvergenceTarget: MuslimCountry = {
     @tailrec def getTarget: MuslimCountry = {
       val rmc = randomMuslimCountry
@@ -2692,7 +2692,7 @@ object LabyrinthAwakening {
     
     if (game.useExpansionRules) {
       if (lapsingEventInPlay(ArabWinter))
-        log("No convergence peformed because \"Arab Winter\" is in effect")
+        log("No convergence performed because \"Arab Winter\" is in effect")
       else {
         val target = randomConvergenceTarget.name
         testCountry(target)
@@ -2807,7 +2807,7 @@ object LabyrinthAwakening {
   }
 
   // Sorts a list column wise.  Returns a list of rows where
-  // eash row is a string with the items of that row lined up
+  // each row is a string with the items of that row lined up
   // with a minimum of two spaces separating the columns.
   def columnFormat(list: List[String], numCols: Int): Seq[String] = {
     def padLeft(s: String, width: Int) = s + (" " * (width - s.length))
@@ -3021,7 +3021,7 @@ object LabyrinthAwakening {
   
   // Given a directory for a saved game finds the most recent save file.
   // Files can be named play-n or turn-n
-  // If any play-n files exist take the one with the hightest number, otherwise
+  // If any play-n files exist take the one with the highest number, otherwise
   // take the turn-n file with the highest number.
   def mostRecentSaveFile(name: String): Option[GameFile] = {
     case class Entry(score: Int, file: GameFile)
@@ -3062,7 +3062,7 @@ object LabyrinthAwakening {
           else
             name
         case name => 
-          println("Game names must consist of one or more letters, numbers, spaces, dashes or undercores")
+          println("Game names must consist of one or more letters, numbers, spaces, dashes or underscores")
           getName
       }
     }
@@ -3160,7 +3160,7 @@ object LabyrinthAwakening {
     show(from.reserves.jihadist, to.reserves.jihadist, s"Set Jihadist reserves to ${to.reserves.jihadist}")
     show(from.troopsAvailable, to.troopsAvailable, 
           s"Set troops on the track to ${to.troopsAvailable} (${to.troopCommitment})") 
-    show(from.offMapTroops, to.offMapTroops, s"Set troops in of map box to ${to.offMapTroops}")
+    show(from.offMapTroops, to.offMapTroops, s"Set troops in off-map box to ${to.offMapTroops}")
     show(from.militiaAvailable, to.militiaAvailable, s"Set available militia to ${to.militiaAvailable}")
     show(from.funding, to.funding, s"Set jihadist funding to ${to.funding} (${to.fundingLevel})")
     show(from.cellsOnTrack, to.cellsOnTrack, s"Set cells on the funding track to ${to.cellsOnTrack}")
@@ -3421,7 +3421,7 @@ object LabyrinthAwakening {
         // If there are any markers representing troops or
         // if there is a mix of multiple type of cubes that can take losses (troops and militia),
         // and the hits are not sufficient to eliminate all forces present, 
-        // then allow the user to choose which units aborb the losses.
+        // then allow the user to choose which units absorb the losses.
         val mixedCubes = m.troops > 0 && m.militia > 0
         if (losses >= m.totalTroopsAndMilitia)
            (m.troopsMarkers map (_.name), m.troops, m.militia)
@@ -3512,7 +3512,7 @@ object LabyrinthAwakening {
     }
   }
   
-  //  Perform Civial War attrition in the named country
+  //  Perform Civil War attrition in the named country
   //
   //  Note:
   //  There is a special case here for Nigeria.
@@ -3537,7 +3537,7 @@ object LabyrinthAwakening {
 
     // Get the fresh instance of the Muslim country
     val m = game.getMuslim(name)
-    // If Siege of Mosul in play then cells are halved and (troops + milita)
+    // If Siege of Mosul in play then cells are halved and (troops + militia)
     // are doubled
     val jihadDie = dieRoll
     val usDie    = dieRoll
@@ -3574,7 +3574,7 @@ object LabyrinthAwakening {
           val delta = unfulfilledJihadHits - unfulfilledUSHits
           if (delta == 0) {
             if (unfulfilledJihadHits != 0)
-              log(s"Both sides have ${amountOf(unfulfilledJihadHits, "unfulfilled hit")}.  No futher effects.")
+              log(s"Both sides have ${amountOf(unfulfilledJihadHits, "unfulfilled hit")}.  No further effects.")
           }
           else {
             if (unfulfilledJihadHits > 0)
@@ -3645,13 +3645,13 @@ object LabyrinthAwakening {
             addMilitiaToCountry(m.name, num)          
         }
         else {
-          //  There are not enough available milita for all Advisors so
+          //  There are not enough available militia for all Advisors so
           //  ask where to place them.
           if (game.humanRole == US) {
             var advisorMap: Map[String, Int] = (civilWars filter (_.numAdvisors > 0) map (m => (m.name, m.numAdvisors))).toMap 
             def nextMilita(numLeft: Int): Unit = if (numLeft > 0) {
               val unfulfilled = advisorMap.values.sum
-              val target      = askCountry("Place milita in which country: ", advisorMap.keys.toList.sorted)
+              val target      = askCountry("Place militia in which country: ", advisorMap.keys.toList.sorted)
               val numAdvisors = advisorMap(target)
               val maxNum      = numAdvisors min numLeft
               val num         = askInt(s"Place how many militia in $target", 1, maxNum)
@@ -3663,7 +3663,7 @@ object LabyrinthAwakening {
               nextMilita(numLeft - num)
               
             }
-            println("\nThere are more Advisors markers than available milita")
+            println("\nThere are more Advisors markers than available militia")
             nextMilita(game.militiaAvailable)
             
           }
@@ -3751,7 +3751,8 @@ object LabyrinthAwakening {
   }
 
   // • Deploy at least six troops into the country.
-  // • Place a green Regime Change marker on them (4.8.2). • Roll its Governance on the Country Tests table.
+  // • Place a green Regime Change marker on them (4.8.2).
+  // • Roll its Governance on the Country Tests table.
   // • Shift its Alignment to Ally.
   // • Shift any Sleeper cells there to Active (4.7.4.1).
   // • Roll Prestige
@@ -3770,7 +3771,7 @@ object LabyrinthAwakening {
       activeCells  = m.activeCells + m.sleeperCells,
       sleeperCells = 0
     ))
-    log(s"Place a green regime change maker in $dest")
+    log(s"Place a green regime change marker in $dest")
     log(s"Set governance of ${m.name} ${govToString(newGov)}")
     log(s"Set alignment of ${m.name} Ally")
     if (m.sleeperCells > 0)
@@ -3951,7 +3952,7 @@ object LabyrinthAwakening {
         log(if (success) "Success" else "Failure")
           
         if (success) {
-          // Ask the user which plot to place.  The Bot take a random plot regardless of ops spent.
+          // Ask the user which plot to place.  The Bot takes a random plot regardless of ops spent.
           val plots = if (game.humanRole == Jihadist)
             askAvailablePlots(1, ops)
           else if (game.jihadistIdeology(Attractive)) {
@@ -4028,11 +4029,11 @@ object LabyrinthAwakening {
           else
             removeCellsFromCountry(name, failures, 0, false, addCadre = false)
         
-        // Remove 1 aid marker for each sucessful die roll
+        // Remove 1 aid marker for each successful die roll
         removeAidMarker(name, successes min m.aidMarkers)
         worsenGovernance(name, levels = successes, canShiftToIR = majorSuccess)
         // A major jihad failure rolling 3 dice in a country that was 
-        // already at Poor governance before the operation begain will
+        // already at Poor governance before the operation began will
         // add a besieged regime marker and shift alignment toward ally
         if (major && !majorSuccess && m.governance == Poor && numAttempts == 3) {
           addBesiegedRegimeMarker(name)
@@ -4097,7 +4098,7 @@ object LabyrinthAwakening {
   }
 
   // Note: The caller is responsible for handling convergence and the possible
-  //       displacement of the caliphate captial.
+  //       displacement of the caliphate capital.
   def improveGovernance(name: String, levels: Int, canShiftToGood: Boolean, endOfTurn: Boolean = false,
                         convergenceOK: Boolean = true): Unit = {
     if (levels > 0) {
@@ -4116,7 +4117,7 @@ object LabyrinthAwakening {
           if (m.aidMarkers > 0  ) log(s"Remove ${amountOf(m.aidMarkers, "aid marker")} from $name")
           if (m.awakening > 0   ) log(s"Remove ${amountOf(m.awakening, "awakening marker")} from $name")
           if (m.reaction > 0    ) log(s"Remove ${amountOf(m.reaction, "reaction marker")} from $name")
-          if (m.militia > 0     ) log(s"Remove ${m.militia} miltia from $name")
+          if (m.militia > 0     ) log(s"Remove ${m.militia} militia from $name")
 
           val improved = m.copy(governance = Good, awakening = 0, reaction = 0, aidMarkers = 0,
                  militia = 0, besiegedRegime = false)
@@ -4165,7 +4166,7 @@ object LabyrinthAwakening {
           log(s"Set governance of $name to ${govToString(newGov)}")
           increaseFunding(m.resourceValue)
           if (m.totalTroopsThatAffectPrestige > 0) {
-            log(s"Set US prestige to 1  (troops present)")
+            log(s"Set US prestige to 1 (troops present)")
             game = game.copy(prestige = 1)
           }
           // Always remove aid when degraded to IR
@@ -4173,7 +4174,7 @@ object LabyrinthAwakening {
           if (m.aidMarkers > 0) log(s"Remove ${amountOf(m.aidMarkers, "aid marker")} from $name")
           if (m.awakening > 0 ) log(s"Remove ${amountOf(m.awakening, "awakening marker")} from $name")
           if (m.reaction > 0  ) log(s"Remove ${amountOf(m.reaction, "reaction marker")} from $name")
-          if (m.militia > 0   ) log(s"Remove ${m.militia} miltia from $name")
+          if (m.militia > 0   ) log(s"Remove ${m.militia} militia from $name")
           val degraded = m.copy(
             governance = IslamistRule, alignment = Adversary, awakening = 0, reaction = 0, 
             aidMarkers = 0, militia = 0, besiegedRegime = false)
@@ -4283,7 +4284,7 @@ object LabyrinthAwakening {
       removeAidMarker(name, m.aidMarkers)
       removeAwakeningMarker(name, m.awakening)
       removeReactionMarker(name, m.reaction)
-      // Ending the regime change orcivil war will also remove the caliphateCapital
+      // Ending the regime change or civil war will also remove the caliphateCapital
       // status if it is in effect
       endRegimeChange(name)
       endCivilWar(name)
@@ -4308,7 +4309,7 @@ object LabyrinthAwakening {
     val n = game.getNonMuslim(name)
     assert(n.canChangePosture, s"Cannot set posture in $name")
     if (n.posture == newPosture) 
-      log(s"The posture of $name reamins $newPosture")
+      log(s"The posture of $name remains $newPosture")
     else {
       game = game.updateCountry(n.copy(postureValue = newPosture))
       log(s"Set posture of $name to $newPosture")
@@ -4459,19 +4460,19 @@ object LabyrinthAwakening {
     //  Place the appropriate event marker on the board
     event match {
       case TrainingCamps =>
-        assert(targetCountry.nonEmpty, "placeExtraCells() called with emtpy targetCountry")
+        assert(targetCountry.nonEmpty, "placeExtraCells() called with empty targetCountry")
         addEventMarkersToCountry(targetCountry, TrainingCamps)
         
       case AlBaghdadi =>
         addGlobalEventMarker(AlBaghdadi)
         
       case e =>
-        throw new IllegalArgumentException("placeExtraCells() invlalid event")
+        throw new IllegalArgumentException("placeExtraCells() invalid event")
     }
     
     game.extraCellEvent match {
       case Some(prevEvent) =>
-        log(s"The $prevEvent event already is in play so no extra cells are added.")
+        log(s"The $prevEvent event is already in play so no extra cells are added.")
         log("Extra cells will not be removed from play as long as either")
         log(s"$TrainingCamps or $AlBaghdadi is on the board.")
       case None =>
@@ -4499,8 +4500,8 @@ object LabyrinthAwakening {
     }    
   }
   
-  // This is called whenever somthing happens that can change
-  // the capcaity for extra cells.
+  // This is called whenever something happens that can change
+  // the capacity for extra cells.
   //    Caliphate declared/displaced
   //    Training Camps and AlBaghdadi events no longer in play
   //
@@ -4679,9 +4680,9 @@ object LabyrinthAwakening {
       val startingCommitment = game.troopCommitment      
       def disp(name: String) = if (name == "track") "the troops track" else name
         
-      log(s"Move ${amountOf(num, "troop")} from ${disp(source)} to the off map box")
+      log(s"Move ${amountOf(num, "troop")} from ${disp(source)} to the off-map box")
       // Note: No need to "remove" them from the track as the number on the track is
-      // calcualted base on those on the map and in the off map box.
+      // calculated based on those on the map and in the off map box.
       if (source == "track")
         assert(game.troopsAvailable >= num, "takeTroopsOffMap(): Not enough troops available on track")
       else {
@@ -4702,9 +4703,9 @@ object LabyrinthAwakening {
       val startingCommitment = game.troopCommitment
       
       def disp(name: String) = if (name == "track") "the troops track" else name
-      log(s"Move ${amountOf(num, "troop")} from the off map box to the troops track")
+      log(s"Move ${amountOf(num, "troop")} from the off-map box to the troops track")
       // Note: No need to "add" them from the track as the number on the track is
-      // calcualted base on those on the map and in the off map box.
+      // calculated based on those on the map and in the off-map box.
       game = game.copy(offMapTroops = game.offMapTroops - num)
       
       if (game.troopCommitment != startingCommitment)
@@ -4726,7 +4727,7 @@ object LabyrinthAwakening {
   def removeMilitiaFromCountry(name: String, num: Int): Unit = {
     if (num > 0) {
       val m = game.getMuslim(name)
-      assert(m.militia >= num, s"removeilitiaFromCountry(): Not enough militia in $name")
+      assert(m.militia >= num, s"removeMilitiaFromCountry(): Not enough militia in $name")
       game = game.updateCountry(m.copy(militia = m.militia - num))
       log(s"Remove $num militia from $name to the track")
     }
@@ -4905,7 +4906,7 @@ object LabyrinthAwakening {
       if (num == 1)
         log(s"Flip 1 active cell in $name to a sleeper cell")
       else 
-        log(s"Flip $num active cells in $name to a sleeper cells")
+        log(s"Flip $num active cells in $name to sleeper cells")
       c match {
         case m: MuslimCountry    => game = game.updateCountry(
           m.copy(sleeperCells = m.sleeperCells + num, activeCells = m.activeCells - num))
@@ -5080,7 +5081,7 @@ object LabyrinthAwakening {
   def removeAvailableWMD(num: Int, bumpPrestige: Boolean = true): Unit = {
     log(s"Permanently remove ${amountOf(num, "WMD plot")} from the available plots box")
     val wmd = (game.availablePlots.sorted takeWhile (_ == PlotWMD)).size
-    assert(wmd >= num, "removeAvailableWMD(): not enought WMD plots available")
+    assert(wmd >= num, "removeAvailableWMD(): not enough WMD plots available")
     val updatedPlots = game.plotData.copy(
       availablePlots = game.availablePlots.sorted drop num,
       removedPlots   = (game.availablePlots.sorted take num) ::: game.removedPlots
@@ -5196,7 +5197,7 @@ object LabyrinthAwakening {
             // Funding
             if (mapPlot.plot == PlotWMD && mapPlot.backlashed) {
               game = game.copy(funding = 1)
-              log(s"Set funding to 1.  (WMD Plot that was backlashed)")
+              log(s"Set funding to 1 (WMD Plot that was backlashed)")
             }
             else if (m.isGood) {
               val delta = if (mapPlot.backlashed) -2 else 2
@@ -5219,7 +5220,7 @@ object LabyrinthAwakening {
             }
             // Sequestration
             if (mapPlot.plot == PlotWMD && game.sequestrationTroops) {
-              returnSequestrationTroopsToAvailable("\nResolved WMD plot releases the off map Sequestration troops")
+              returnSequestrationTroopsToAvailable("\nResolved WMD plot releases the off-map Sequestration troops")
             }
             
             // rule 11.2.6    (WMD in Civil War)
@@ -5246,7 +5247,7 @@ object LabyrinthAwakening {
                 val successes = dice count isSuccess
                 val diceStr = dice map (d => s"$d (${if (isSuccess(d)) "success" else "failure"})")
                 log(s"Dice rolls to degrade governance: ${diceStr.mkString(", ")}")
-                // Remove 1 aid marker for each sucessful die roll
+                // Remove 1 aid marker for each successful die roll
                 removeAidMarker(name, successes min m.aidMarkers)
                 if (!m.isIslamistRule)
                   worsenGovernance(name, levels = successes, canShiftToIR = false)
@@ -5433,7 +5434,7 @@ object LabyrinthAwakening {
     log()
     log("The Awakening cards were added to the deck.")
     log("The Awakening expansion rules are now in effect.")
-    log("The Bot will now use the Awakening priorites.")
+    log("The Bot will now use the Awakening priorities.")
     // If Syria is under Islamist rule then the WMD cache should be added to the available plots.
     val (updatedPlots, syriaCache) = if (syria.isIslamistRule)
       (game.plotData.copy(availablePlots = PlotWMD :: PlotWMD :: game.availablePlots), 0)
@@ -5455,7 +5456,7 @@ object LabyrinthAwakening {
     }
     log("Iran now contains 1 unavailable WMD plot")
     
-    //  Place an awakening marker in Ageria/Tunisa if possible
+    //  Place an awakening marker in Algeria/Tunisia if possible
     //  otherwise in a random muslim country
     val awakeningTarget = if (algeria.canTakeAwakeningOrReactionMarker)
       AlgeriaTunisia
@@ -5478,7 +5479,7 @@ object LabyrinthAwakening {
     game = game.copy(currentMode = ForeverWarMode)
     log()
     log("The Forever War cards were added to the deck.")
-    log("The Bot will now use the Forever War priorites.")
+    log("The Bot will now use the Forever War priorities.")
   }
   
   def endTurn(): Unit = {
@@ -5601,7 +5602,7 @@ object LabyrinthAwakening {
         log(s"\nFlip green regime change marker in ${rc.name} to its tan side")
       }
     
-      // Reset history list of plays. They are not store in turn files.
+      // Reset history list of plays. They are not stored in turn files.
       game = game.copy(plays = Nil)
       saveTurn()
       saveGameDescription(turnsCompleted = game.turn)
@@ -5703,8 +5704,8 @@ object LabyrinthAwakening {
               }
             }
             val scenario = scenarios(scenarioName)
-            //  campaing always false when starting with a scenario in the
-            //  lastest expansion
+            //  campaign always false when starting with a scenario in the
+            //  latest expansion
             val campaign = if (scenario.startingMode == ForeverWarMode)
               false
             else {
@@ -5723,7 +5724,7 @@ object LabyrinthAwakening {
             val humanRole = cmdLineParams.side orElse
                             configParams.side getOrElse {
               // ask which side the user wishes to play
-              val sidePrompt = "Which side do you wish play? (US or Jihadist) "
+              val sidePrompt = "Which side do you wish to play? (US or Jihadist) "
               Role(askOneOf(sidePrompt, "US"::"Jihadist"::Nil, allowAbort = false).get)
             }
             val difficulties = if (humanRole == US)
@@ -6328,7 +6329,7 @@ object LabyrinthAwakening {
   // the action phase.  Hence the `additional` parameter.
   def usCardPlay(param: Option[String], additional: Boolean = false): Unit = {
     // If we are entering a new action phase,
-    // resolve plots if necesary and reset the phase targets
+    // resolve plots if necessary and reset the phase targets
     val (newPhase, skippedPlotResolution) = if (additional) (false, false)
                                             else newActionPhase(US)
     if (newPhase) {
@@ -6467,7 +6468,7 @@ object LabyrinthAwakening {
 
     // If the the event is US elections or is associated with the Jihadist
     // Ask if user want so resolve event or operation first
-    // If the choose to resovle the event first, do so before
+    // If they choose to resolve the event first, do so before
     // prompting for the action because the ramifications of the event
     // may affect what actions are possible.
     val actionOrder = if (card.autoTrigger || (card.association == Jihadist && lapsingEventNotInPlay(FakeNews))) {
@@ -6489,7 +6490,7 @@ object LabyrinthAwakening {
     
     // There will only be a second card if the reassessment action was chosen.
     // If so we must check to see if the event on the second card will trigger
-    // an event.  (The first card event by still have to be triggerd too.)
+    // an event.  (The first card event by still have to be triggered too.)
     val finalOrder = secondCard match {
       case Some(card2) if (card2.autoTrigger || card2.association == Jihadist) =>
         if (card1EventValid)
@@ -6578,7 +6579,7 @@ object LabyrinthAwakening {
     else {
       val src = game getCountry source
       val markers = src.troopsMarkers filter (m => m.canDeploy)
-      // If the sourc is in regime change then we must take care not to allow too many
+      // If the source is in regime change then we must take care not to allow too many
       // markers to be removed so that we do not leave enough troops/militia behind.
       val regimeChange = (game isMuslim source) && (game getMuslim source).inRegimeChange
       val canRemoveAll: List[TroopsMarker] => Boolean = if (regimeChange)
@@ -6727,7 +6728,7 @@ object LabyrinthAwakening {
   
   def jihadistCardPlay(param: Option[String]): Unit = {
     // If we are entering a new action phase,
-    // resolve plots if necesary and reset the phase targets
+    // resolve plots if necessary and reset the phase targets
     val (newPhase, skippedPlotResolution) = newActionPhase(Jihadist)
     if (newPhase) {
       if (skippedPlotResolution) {
@@ -7472,7 +7473,7 @@ object LabyrinthAwakening {
       val nonTargets = countryNames(game.countries) filterNot targets.apply
       val choices = List(
         choice(nonTargets.nonEmpty, "add",  "Add a country to the resolved plot targets"),
-        choice(targets.nonEmpty,    "del",  "Remove a country to the resolved plot targets"),
+        choice(targets.nonEmpty,    "del",  "Remove a country from the resolved plot targets"),
         choice(true,                "done", "Finished")
       ).flatten
       println("\nCountries where plots were resolved in the last plot resolution phase:")
@@ -7713,7 +7714,7 @@ object LabyrinthAwakening {
         askOneOf(prompt, choices, allowNone = true, allowAbort = false) map govFromString foreach { newGov =>
           // When a country becomes Good or Islamist Rule, the country cannot contain:
           //  aid, besiege regime, civil war, regime change, awakening, reaction
-          // Further when the country becomes Good, it cannot be the Calipate Capital.
+          // Further when the country becomes Good, it cannot be the Caliphate Capital.
           val goodOrIslamist = newGov == Good || newGov == IslamistRule
           val nixCapital      = newGov == IslamistRule && m.caliphateCapital
           val nixAid          = goodOrIslamist && m.aidMarkers != 0
@@ -7735,7 +7736,7 @@ object LabyrinthAwakening {
           warn(nixAwakening, "The awakening markers will be removed.")
           warn(nixReaction, "The reaction markers will be removed.")
           warn(nixTrainingCamps, "The Training Camps marker will be removed")
-          if (!anyWarnings || askYorN(s"Do you wish continue (y/n)? ")) {
+          if (!anyWarnings || askYorN(s"Do you wish to continue (y/n)? ")) {
             var updated = m
             logAdjustment(name, "Governance", govToString(updated.governance), govToString(newGov))
             updated = updated.copy(governance = newGov)
@@ -7744,7 +7745,7 @@ object LabyrinthAwakening {
               updated = updated.copy(alignment = Adversary)
             }
             if (nixCapital) {
-              log(s"$name lost Caliphate Capital status.  Caliphate no longer delcared.")
+              log(s"$name lost Caliphate Capital status.  Caliphate no longer declared.")
               updated = updated.copy(caliphateCapital = false)
             }
             if (nixAid) {
@@ -7783,7 +7784,7 @@ object LabyrinthAwakening {
     val c = game.getCountry(name)
     val maxCells = c.activeCells + game.cellsAvailable
     if (maxCells == 0) {
-      println("There a no cells available to add to this country.")
+      println("There are no cells available to add to this country.")
       pause()
     }
     else 
@@ -7834,7 +7835,7 @@ object LabyrinthAwakening {
     val c = game getCountry name
     val maxTroops = c.troops + game.troopsAvailable
     if (maxTroops == 0) {
-      println("There a no troops available to add to this country.")
+      println("There are no troops available to add to this country.")
       pause()
     }
     else {
@@ -7855,7 +7856,7 @@ object LabyrinthAwakening {
       case m: MuslimCountry =>
         val maxMilitia = m.militia + game.militiaAvailable
         if (maxMilitia == 0) {
-          println("There a no troops available to add to this country.")
+          println("There are no troops available to add to this country.")
           pause()
         }
         else {
@@ -7966,7 +7967,7 @@ object LabyrinthAwakening {
             logAdjustment(name, "Regime change", m.regimeChange, newValue)
             var updated = m.copy(regimeChange = newValue)
             if (nixCapital) {
-              log(s"$name lost Caliphate Capital status.  Caliphate no longer delcared.")
+              log(s"$name lost Caliphate Capital status.  Caliphate no longer declared.")
               updated = updated.copy(caliphateCapital = false)
             }
             game = game.updateCountry(updated)
@@ -8116,7 +8117,7 @@ object LabyrinthAwakening {
     }
   }  
     
-  // Note: Advisors are not handle by this function because a country can contain
+  // Note: Advisors are not handled by this function because a country can contain
   //       multiple Advisors markers.  Set adjustCountryAdvisors()
   def adjustCountryMarkers(name: String): Unit = {
     val country = game.getCountry(name)

--- a/src/main/scala/awakening/SavedGame.scala
+++ b/src/main/scala/awakening/SavedGame.scala
@@ -180,7 +180,7 @@ object SavedGame {
     val params = asMap(data("params"))
     asString(data("playType")) match {
       case "PlayedCard"       => PlayedCard(Role(asString(params("role"))), asInt(params("cardNum")))
-      case "PlayedReassement" => PlayedReassement(asInt(params("card1")), asInt(params("card2")))
+      case "PlayedReassessment" => PlayedReassement(asInt(params("card1")), asInt(params("card2")))
       case "AdditionalCard"   => AdditionalCard(Role(asString(params("role"))), asInt(params("cardNum")))
       case "PlotsResolved"    => PlotsResolved(asInt(params("num")))
       case "AdjustmentMade"   => AdjustmentMade(asString(params("desc")))

--- a/src/main/scala/awakening/USBot.scala
+++ b/src/main/scala/awakening/USBot.scala
@@ -123,8 +123,8 @@ object USBot extends BotHelpers {
     override def toString() = desc
   }
   
-  // Boolean criteria filter used with Alert Prioities Table
-  // The input is fitered and if the results are empty, the original input
+  // Boolean criteria filter used with Alert Priorities Table
+  // The input is filtered and if the results are empty, the original input
   // is returned. Otherwise the filtered input is returned.
   class PlotCriteria(val desc: String, criteria: (PlotInCountry) => Boolean) extends PlotFilter {
     def filter(plots: List[PlotInCountry]) = (plots filter criteria) match {
@@ -133,7 +133,7 @@ object USBot extends BotHelpers {
     }
   }
   
-  // Highest integer score filter used with Alert Prioities Table.
+  // Highest integer score filter used with Alert Priorities Table.
   // Applies the given score function to each plot in the input list and
   // takes the highest value.
   // Then returns the list of plots whose score matches that highest value.
@@ -145,7 +145,7 @@ object USBot extends BotHelpers {
     }
   }
   
-  // Calculate the resutling funding if the plot were to be resolved.
+  // Calculate the resulting funding if the plot were to be resolved.
   def fundingResult(plot: PlotInCountry): Int = {
     val funding = game.funding
     plot.country match {
@@ -202,7 +202,7 @@ object USBot extends BotHelpers {
   // Process the list of PlotInCountry instances by each PlotFilter in the priorities list.
   // In this function each filter is processed in order until we have used all filters
   // in the list to narrow the choices to a single country.  If we go through all of
-  // the filters and we stil have more than one viable country, then we pick one at
+  // the filters and we still have more than one viable country, then we pick one at
   // random.
   def priorityPlot(plots: List[PlotInCountry]): PlotInCountry = {
     assert(plots.nonEmpty, "priorityPlot() called with empty list")
@@ -369,7 +369,7 @@ object USBot extends BotHelpers {
   
 
   // ------------------------------------------------------------------
-  // US Alert Resoulution Flowchart definitions.
+  // US Alert Resolution Flowchart definitions.
   
   trait AlertFlowchartNode
   
@@ -502,8 +502,8 @@ object USBot extends BotHelpers {
   val RegimeChangePriority = new CriteriaFilter("Regime Change",
                   muslimTest(_.inRegimeChange))
   
-  //  3. Caliphate Captial
-  val CaliphateCaptialPriority = new CriteriaFilter("Caliphate Captial",
+  //  3. Caliphate Capital
+  val CaliphateCaptialPriority = new CriteriaFilter("Caliphate Capital",
                   muslimTest(_.caliphateCapital))
 
   //  4. Pakistan Arsenal
@@ -629,7 +629,7 @@ object USBot extends BotHelpers {
   }
   
   object DisruptForPrestigeDecision extends OperationDecision {
-    val desc = "Disrupt for Pestige gain?"
+    val desc = "Disrupt for Prestige gain?"
     def yesPath = Disrupt
     def noPath  = USSoftDecision
     def condition(ops: Int) = game.disruptMuslimTargets(ops) map game.getMuslim exists { m => 
@@ -1106,7 +1106,7 @@ object USBot extends BotHelpers {
       game.disruptLosses(name) match {
         case Some(Left(numCells)) =>
           //  If we would disrupt the last cells on the map and they are
-          //  not sleeper cells, then we weould remove last cell from the map
+          //  not sleeper cells, then we would remove last cell from the map
           numCells == game.totalCellsOnMap && game.getCountry(name).sleeperCells == 0
         
         case _ => false  // Would only disrupt a cadre
@@ -1172,7 +1172,7 @@ object USBot extends BotHelpers {
       // the first see if Reassessment is possible.  If Reassessment is
       // not performed, then finally we consult the PAR flowchart.
       if (consultPAR && !reassessment(card)) {
-        // If the event is playable then the event is alwasy executed
+        // If the event is playable then the event is always executed
         if (playable) {
           performCardEvent(card, US)
           // If the card event is Unassociated add ops to the Bot's reserves.
@@ -1411,7 +1411,7 @@ object USBot extends BotHelpers {
   // If this value is less than the number of Ops on the card, then we will 
   // perform homeland using the remainder of ops on the card plus reserves as needed.
   // This may result in more than 3 total Ops being used for the current card.
-  // But no single operation can be peformed using only resrvere ops.
+  // But no single operation can be performed using only reserve ops.
   // If the opUsed is greater than or equal to the number of Ops on the card,
   // then we do nothing.
   def homelandSecurity(card: Card, opsUsed: Int): Unit = {

--- a/src/main/scala/awakening/scenarios/MissionAccomplished.scala
+++ b/src/main/scala/awakening/scenarios/MissionAccomplished.scala
@@ -75,7 +75,7 @@ object MissionAccomplished extends Scenario {
   override val additionalSetup: () => Unit = () => {
     // The Jihadist player rolls the posture of each Schengen country.
     for (name <- Schengen)
-      rollCountryPosture(name, 0, false)
+      rollCountryPosture(name, logWorld = false)
     logWorldPosture()
   }
 }

--- a/src/other/README.txt
+++ b/src/other/README.txt
@@ -13,14 +13,14 @@ Linux.
 
 To run the program
 -----------------------------------------------------------------------
-1. Ensure that Java is installed on you system and that the java 
+1. Ensure that Java is installed on your system and that the java
    executable can be found on your PATH.
    
 2. Run the awakening script located in the same directory
    as this README file. (On Windows, use the awakening.cmd script)
 
-3. If all is well the game will prompt you for a scenario and you
-   will be off an running.
+3. If all is well, the game will prompt you for a scenario and you
+   will be off and running.
    
    
 More Details
@@ -35,11 +35,11 @@ More Details
    type 'Sau'
    
 3. Your game will automatically be saved after each card play.
-   When you resume a game in progress the game will load the most
+   When you resume a game in progress, the game will load the most
    recent save file.
    The games are saved in a 'games' subdirectory that is created
    in the same directory as this README file.  Each game will have
-   its own subdirectory within 'games'.  To delete a saved game
+   its own subdirectory within 'games'.  To delete a saved game,
    simply delete its corresponding subdirectory.
    
 4. There is a 'resolve plot' command, but you should rarely need to 
@@ -47,13 +47,13 @@ More Details
    automatically.
  
 5. Once all cards have been played by both sides, use the 'end turn'
-   command to do all of the end of turn stuff.  If there are 
+   command to do all the end of turn stuff.  If there are
    unresolved plots on the map, they will be resolved first.  
    
-6. You can use the 'rollback' command to rollback to the beginning
+6. You can use the 'rollback' command to roll back to the beginning
    of a previous card play, or the beginning of a previous turn.
    
-7. Look at the help for the 'show', 'history' commands.  The are
+7. Look at the help for the 'show' and 'history' commands.  They are
    very useful for making sure your board is in sync with the game.
    If you find any inconsistencies, you can use the 'adjust' command.
    

--- a/src/other/awakening_config
+++ b/src/other/awakening_config
@@ -2,7 +2,7 @@
 # You can set up default parameters in this file
 # to avoid being prompted when you start a new game.
 #
-# Note that any values you specifiy on the command line will
+# Note that any values you specify on the command line will
 # override values in this file.
 
 # Name of the scenario to play
@@ -19,7 +19,7 @@ scenario =
 # The side that you wish to play:  US or Jihadist
 side =
 
-# Difficulty level.  Must be an number from 1 to 6.
+# Difficulty level.  Must be a number from 1 to 6.
 # For the Jihadist Bot:
 # 1 = Muddled
 # 2 = Muddled,Coherent
@@ -41,7 +41,7 @@ level =
 # will be used when playing against the Jihadist Bot.
 # Note that setting the 'ideology' parameter will override any
 # value you have set for the 'level' parameter
-# The value can be any combination of the of following 
+# The value can be any combination of the following
 # separated by commas:
 # Muddled,Coherent,Attractive,Potent,Infectious,Virulent 
 #
@@ -52,11 +52,10 @@ ideology =
 # will be used when playing against the US Bot.
 # Note that setting the 'us-resolve' parameter will override any
 # value you have set for the 'level' parameter.
-# The value can be any combination of the of following 
+# The value can be any combination of the following,
 # separated by commas:
 # Off Guard,Competent,Adept,Vigilant,Ruthless,NoMercy 
 us-resolve =
-
 
 # Set how the program handles dice rolled by the human player.
 # Can be set to one of: auto, human


### PR DESCRIPTION
This PR fixes a number of typos in:

- code comments
- log messages
- other strings (e.g. "REASSESSMENT"); I'm not sure if this will break anything like restoring saved games, so feel free to ignore this specific change (which from memory is in two places, it should be easy to search for)